### PR TITLE
UTF-8 by default; so help information displays correctly

### DIFF
--- a/src/default
+++ b/src/default
@@ -76,6 +76,8 @@ server {
         ssl_certificate     /etc/clas-digital/bin/cert.pem;
         ssl_certificate_key /etc/clas-digital/bin/key.pem;
 	server_name www.clas-digital.uni-frankfurt.de;
+
+	charset utf-8;
 	
 	autoindex on;
 	autoindex_exact_size off;
@@ -211,6 +213,8 @@ server {
         ssl_certificate_key /etc/clas-digital/bin/key.pem;
 	server_name www.clas-digital.uni-frankfurt.de;
 	
+	charset utf-8;
+
 	autoindex on;
 	autoindex_exact_size off;
 	autoindex_format html;


### PR DESCRIPTION
Hopefully resolves #169